### PR TITLE
Redis implementation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,4 +9,5 @@
   :profiles {:dev {:dependencies [[org.clojure/data.fressian "0.2.1"]
                                   [amazonica "0.3.77"]
                                   [cheshire "5.6.3"]
-                                  [com.taoensso/nippy "2.12.2"]]}})
+                                  [com.taoensso/nippy "2.13.0"]
+                                  [com.taoensso/carmine "2.16.0"]]}})

--- a/src/riverford/durable_ref/scheme/redis/carmine.clj
+++ b/src/riverford/durable_ref/scheme/redis/carmine.clj
@@ -20,7 +20,20 @@
 
   atomic:redis:tcp://localhost:6379/0/atoms/a2-ref.edn
 
-  inserts another entry in the top-level atoms key in Redis, and so on."
+  inserts another entry in the top-level atoms key in Redis, and so on.
+
+  To be able to use Clojure's reference type interfaces you can add the Redis credentials
+  using `add-credentials!`, and remove them again when no longer needed with `remove-credentials!`.
+  Example, with Redis password \"foobar\":
+
+  `(add-credentials! \"localhost\" 6379 \"foobar\")`
+  `(def ref-1 (dref/reference \"atomic:redis:tcp://localhost:6379/0/ref-1.edn\"))`
+  `@ref-1 ;=> nil`
+  `(reset! ref-1 {:foo #{:a :b}})`
+  `@ref-1 ;=> {:foo #{:a :b}}`
+  `(swap! ref-1 assoc :bar 42)`
+  `@ref-1 ;=> {:foo #{:a :b} :bar 42}`
+  "
   (:require
     [clojure.edn :as edn]
     [clojure.string :as str]

--- a/src/riverford/durable_ref/scheme/redis/carmine.clj
+++ b/src/riverford/durable_ref/scheme/redis/carmine.clj
@@ -79,9 +79,9 @@
   (let [connection (uri->connection uri)
         credentials (get-credentials opts connection)
         [db k] (location uri)]
-    (car/wcar (-> connection
-                  (assoc-in [:spec :password] (or (:password credentials) ""))
-                  (assoc-in [:spec :db] db))
+    (car/wcar (cond-> connection
+                  (:password credentials) (assoc-in [:spec :password] (:password credentials))
+                  true (assoc-in [:spec :db] db))
               (car/set k bytes))))
 
 (defmethod dref/read-bytes "redis"
@@ -89,9 +89,9 @@
   (let [connection (uri->connection uri)
         credentials (get-credentials opts connection)
         [db k] (location uri)
-        conn-w-creds (-> connection
-                         (assoc-in [:spec :password] (or (:password credentials) ""))
-                         (assoc-in [:spec :db] db))]
+        conn-w-creds (cond-> connection
+                         (:password credentials) (assoc-in [:spec :password] (:password credentials))
+                         true (assoc-in [:spec :db] db))]
     (car/wcar conn-w-creds
               (car/get k))))
 
@@ -100,9 +100,9 @@
   (let [connection (uri->connection uri)
         credentials (get-credentials opts connection)
         [db k] (location uri)]
-    (car/wcar (-> connection
-                  (assoc-in [:spec :password] (or (:password credentials) ""))
-                  (assoc-in [:spec :db] db))
+    (car/wcar (cond-> connection
+                  (:password credentials) (assoc-in [:spec :password] (:password credentials))
+                  true (assoc-in [:spec :db] db))
               (car/del k))))
 
 (defmethod dref/do-atomic-swap! "redis"
@@ -112,9 +112,9 @@
         [db k] (location uri)
         deserialize (dref/get-deserializer uri)
         serialize (dref/get-serializer uri)
-        conn (-> connection
-                 (assoc-in [:spec :password] (or (:password credentials) ""))
-                 (assoc-in [:spec :db] db))]
+        conn (cond-> connection
+                 (:password credentials) (assoc-in [:spec :password] (:password credentials))
+                 true (assoc-in [:spec :db] db))]
     (let [[_ [_ res-raw]] (car/atomic conn 100
                                       (car/watch k)
                                       (let [curr-raw (car/with-replies (car/get k))

--- a/src/riverford/durable_ref/scheme/redis/carmine.clj
+++ b/src/riverford/durable_ref/scheme/redis/carmine.clj
@@ -79,7 +79,7 @@
 
 (defn- get-credentials
   [opts connection]
-  (let [c1 (:credentials opts)
+  (let [c1 (-> opts :scheme :redis :carmine :credentials)
         c2 (get @credentials
                 (str (get-in connection [:spec :host])
                      ":"

--- a/src/riverford/durable_ref/scheme/redis/carmine.clj
+++ b/src/riverford/durable_ref/scheme/redis/carmine.clj
@@ -1,0 +1,139 @@
+(ns riverford.durable-ref.scheme.redis.carmine
+  "Carmine-backed Redis implementation.
+
+  Supports the following reference types:
+
+  - atomic
+  - value
+  - volatile
+
+  References follow the scheme <reftype>:redis:tcp://<host>:<port>/<dbnumber>/<key>.<format>, e.g.:
+
+  atomic:redis:tcp://localhost:6379/0/atom-ref.edn
+
+  Keys can be namespaced further, e.g.
+
+  atomic:redis:tcp://localhost:6379/0/atoms/a1-ref.edn
+
+  This results in the top-level atoms key in Redis being a hash map with a single
+  entry a1-ref.edn. A second ref,
+
+  atomic:redis:tcp://localhost:6379/0/atoms/a2-ref.edn
+
+  inserts another entry in the top-level atoms key in Redis, and so on."
+  (:require
+    [clojure.edn :as edn]
+    [clojure.string :as str]
+    [riverford.durable-ref.core :as dref]
+    [taoensso.carmine :as car])
+  (:import
+    (java.net URI)))
+
+(defonce connections (atom {}))
+(defonce credentials (atom {}))
+
+(defn add-credentials!
+  [host port password]
+  (swap! credentials assoc (str host ":" port) {:password password}))
+
+(defn remove-credentials!
+  [host port]
+  (swap! credentials dissoc (str host ":" port)))
+
+(defn- uri->connection
+  [^URI uri]
+  (let [sub-uri (URI. (.getSchemeSpecificPart uri))
+        path (.getPath sub-uri)]
+    (if-let [connection (get @connections (.getHost sub-uri))]
+      connection
+      (let [new-connection {:pool {}
+                            :spec {:host (.getHost sub-uri)
+                                   :port (let [port (.getPort sub-uri)]
+                                           (if (pos? port)
+                                             port
+                                             6379))}}]
+        (swap! connections assoc (str (get-in new-connection [:spec :host]) ":" (get-in new-connection [:spec :port])) new-connection)
+        new-connection))))
+
+(defn- location
+  [^URI uri]
+  (let [sub-uri (URI. (.getSchemeSpecificPart uri))
+        path (.getPath sub-uri)
+        [_ db id-or-ns ?id] (str/split path #"/")]
+    [(edn/read-string db)
+     (when ?id id-or-ns)
+     (or ?id id-or-ns)]))
+
+(defn- get-credentials
+  [opts connection]
+  (let [c1 (:credentials opts)
+        c2 (get @credentials
+                (str (get-in connection [:spec :host])
+                     ":"
+                     (get-in connection [:spec :port])))]
+    (or c1 c2)))
+
+(defmethod dref/write-bytes! "redis"
+  [^URI uri bytes opts]
+  (let [connection (uri->connection uri)
+        credentials (get-credentials opts connection)
+        [db ?f k] (location uri)]
+    (car/wcar (-> connection
+                  (assoc-in [:spec :password] (or (:password credentials) ""))
+                  (assoc-in [:spec :db] db))
+              (if ?f
+                (car/hset ?f k bytes)
+                (car/set k bytes)))))
+
+(defmethod dref/read-bytes "redis"
+  [^URI uri opts]
+  (let [connection (uri->connection uri)
+        credentials (get-credentials opts connection)
+        [db ?f k] (location uri)
+        conn-w-creds (-> connection
+                         (assoc-in [:spec :password] (or (:password credentials) ""))
+                         (assoc-in [:spec :db] db))]
+    (car/wcar conn-w-creds
+              (if ?f
+                (car/hget ?f k)
+                (car/get k)))))
+
+(defmethod dref/delete-bytes! "redis"
+  [^URI uri opts]
+  (let [connection (uri->connection uri)
+        credentials (get-credentials opts connection)
+        [db ?f k] (location uri)]
+    (car/wcar (-> connection
+                  (assoc-in [:spec :password] (or (:password credentials) ""))
+                  (assoc-in [:spec :db] db))
+              (if ?f
+                (car/hdel ?f k)
+                (car/del k)))))
+
+(defmethod dref/do-atomic-swap! "redis"
+  [^URI uri f opts]
+  (let [connection (uri->connection uri)
+        credentials (get-credentials opts connection)
+        [db ?f k] (location uri)
+        deserialize (dref/get-deserializer uri)
+        serialize (dref/get-serializer uri)
+        conn (-> connection
+                 (assoc-in [:spec :password] (or (:password credentials) ""))
+                 (assoc-in [:spec :db] db))]
+    (let [[_ [_ res-raw]] (car/atomic conn 100
+                                      (car/watch ?f)
+                                      (let [curr-raw (if ?f
+                                                       (car/with-replies (car/hget ?f k))
+                                                       (car/with-replies (car/get k)))
+                                            curr-val (when curr-raw
+                                                       (deserialize curr-raw opts))]
+                                        (car/multi)
+                                        (if ?f
+                                          (do
+                                            (car/hset ?f k (serialize (f curr-val) opts))
+                                            (car/hget ?f k))
+                                          (do
+                                            (car/set k (serialize (f curr-val) opts))
+                                            (car/get k)))))]
+      (deserialize res-raw opts))))
+

--- a/src/riverford/durable_ref/scheme/redis/carmine.clj
+++ b/src/riverford/durable_ref/scheme/redis/carmine.clj
@@ -101,32 +101,40 @@
   [^URI uri bytes opts]
   (let [connection (uri->connection uri)
         credentials (get-credentials opts connection)
-        [db k] (location uri)]
-    (car/wcar (cond-> connection
-                  (:password credentials) (assoc-in [:spec :password] (:password credentials))
-                  true (assoc-in [:spec :db] db))
-              (car/set k bytes))))
+        [db k] (location uri)
+        conn (-> connection
+                 (assoc-in [:spec :db] db)
+                 (cond->
+                   (:password credentials) (assoc-in [:spec :password] (:password credentials))))]
+    (car/wcar
+      conn
+      (car/set k bytes))))
 
 (defmethod dref/read-bytes "redis"
   [^URI uri opts]
   (let [connection (uri->connection uri)
         credentials (get-credentials opts connection)
         [db k] (location uri)
-        conn-w-creds (cond-> connection
-                         (:password credentials) (assoc-in [:spec :password] (:password credentials))
-                         true (assoc-in [:spec :db] db))]
-    (car/wcar conn-w-creds
-              (car/get k))))
+        conn (-> connection
+                 (assoc-in [:spec :db] db)
+                 (cond->
+                   (:password credentials) (assoc-in [:spec :password] (:password credentials))))]
+    (car/wcar
+      conn
+      (car/get k))))
 
 (defmethod dref/delete-bytes! "redis"
   [^URI uri opts]
   (let [connection (uri->connection uri)
         credentials (get-credentials opts connection)
-        [db k] (location uri)]
-    (car/wcar (cond-> connection
-                  (:password credentials) (assoc-in [:spec :password] (:password credentials))
-                  true (assoc-in [:spec :db] db))
-              (car/del k))))
+        [db k] (location uri)
+        conn (-> connection
+                 (assoc-in [:spec :db] db)
+                 (cond->
+                   (:password credentials) (assoc-in [:spec :password] (:password credentials))))]
+    (car/wcar
+      conn
+      (car/del k))))
 
 (defmethod dref/do-atomic-swap! "redis"
   [^URI uri f opts]
@@ -136,9 +144,10 @@
         [db k] (location uri)
         deserialize (dref/get-deserializer uri)
         serialize (dref/get-serializer uri)
-        conn (cond-> connection
-                 (:password credentials) (assoc-in [:spec :password] (:password credentials))
-                 true (assoc-in [:spec :db] db))
+        conn (-> connection
+                 (assoc-in [:spec :db] db)
+                 (cond->
+                   (:password credentials) (assoc-in [:spec :password] (:password credentials))))
         exec-res (car/wcar
                    conn
                    (loop [idx 1]

--- a/test/riverford/durable_ref/scheme/redis/carmine_integration_test.clj
+++ b/test/riverford/durable_ref/scheme/redis/carmine_integration_test.clj
@@ -1,0 +1,43 @@
+(ns ^:integration riverford.durable-ref.scheme.redis.carmine-integration-test
+  (:require [clojure.test :refer :all]
+            [riverford.durable-ref.scheme.redis.carmine]
+            [riverford.durable-ref.core :as dref])
+  (:import (java.net URI)
+           (java.util UUID)))
+
+(def uri-base
+  (or (System/getenv "DURABLE_REF_TEST_REDIS_PREFIX")
+      (System/getProperty "durable.ref.test.redis.prefix")
+      (.println System/err "Warning: DURABLE_REF_TEST_REDIS_PREFIX not set, skipping some tests.")))
+
+(deftest test-retrieve-non-existant-returns-nil
+  (when uri-base
+    (let [uri (URI. (str uri-base "/0/test-" (UUID/randomUUID)))]
+      (is (nil? (dref/read-bytes uri {}))))))
+
+(deftest test-store-retrieve-round-trip
+  (when uri-base
+    (let [bytes (byte-array (shuffle (vec (.getBytes "loremipsumfoobardsfsdfsdfsfdsfdsf"))))
+          uri (URI. (str uri-base "/0/test-" (UUID/randomUUID)))]
+      (dref/write-bytes! uri bytes {})
+      (is (= (seq bytes)
+             (seq (dref/read-bytes uri {}))))
+      (dref/delete-bytes! uri {}))))
+
+(deftest test-store-delete-cycle
+  (when uri-base
+    (let [bytes (byte-array (shuffle (vec (.getBytes "loremipsumfoobardsfsdfsdfsfdsfdsf"))))
+          uri (URI. (str uri-base "/0/test-" (UUID/randomUUID)))]
+      (dref/write-bytes! uri bytes {})
+      (dref/delete-bytes! uri {})
+      (is (nil? (dref/read-bytes uri {}))))))
+
+(deftest test-concurrent-swaps
+  (when uri-base
+    (let [uri (URI. (str "atomic:" uri-base "/0/test-" (UUID/randomUUID) ".edn"))
+          sub-uri (URI. (.getSchemeSpecificPart uri))
+          futs (doall (repeatedly 25 #(future (Thread/sleep (rand-int 1000))
+                                               (dref/do-atomic-swap! sub-uri (fnil inc 0) {}))))]
+      (run! deref futs)
+      (is (= 25 (dref/value uri)))
+      (dref/delete-bytes! sub-uri {}))))


### PR DESCRIPTION
This PR implements the atomic, value, and volatile reference types with a Redis backed. Carmine was chosen for the fact that it is the simplest to work with given the constraints, i.e. atomic operations, and because nippy was already a dependency of this library.

I would like to discuss a merge of this into master, as well as a design decision I made: That keys can be namespaced. On the surface this seems like a necessary decision if we want to store large maps that receive frequent updates, however I do not know if in reality it is a premature optimization.

Tests are still missing.